### PR TITLE
Add Discourse Forum Support for Storytime

### DIFF
--- a/app/helpers/storytime/application_helper.rb
+++ b/app/helpers/storytime/application_helper.rb
@@ -40,10 +40,12 @@ module Storytime
     end
 
     def render_comments
-      if Storytime.disqus_forum_shortname.blank?
-        render "storytime/comments/comments"
-      else
+      if Storytime.disqus_forum_shortname.present?
         render "storytime/comments/disqus"
+      elsif Storytime.discourse_name.present?
+        render "storytime/comments/discourse"
+      else
+        render "storytime/comments/comments"
       end
     end
 

--- a/app/views/storytime/comments/_discourse.html.erb
+++ b/app/views/storytime/comments/_discourse.html.erb
@@ -4,7 +4,7 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
           var discourseUrl = "<%= Storytime.discourse_name %>",
-                  discourseEmbedUrl = '<%= url_for( request.original_url) %>';
+                  discourseEmbedUrl = '<%= path_for( request.original_url) %>';
 
           (function() {
               var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;

--- a/app/views/storytime/comments/_discourse.html.erb
+++ b/app/views/storytime/comments/_discourse.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-12">
     <div class="comments">
-      <div id="disqus_thread"></div>
+      <div id="discourse-comments"></div>
       <script type="text/javascript">
           var discourseUrl = "<%= Storytime.discourse_name %>",
                   discourseEmbedUrl = '<%= path_for( request.original_url) %>';

--- a/app/views/storytime/comments/_discourse.html.erb
+++ b/app/views/storytime/comments/_discourse.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="comments">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+          var discourseUrl = "<%= Storytime.discourse_name %>",
+                  discourseEmbedUrl = '<%= url_for( request.original_url) %>';
+
+          (function() {
+              var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+              d.src = discourseUrl + 'javascripts/embed.js';
+              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+          })();
+      </script>
+    </div>
+  </div>
+</div>
+

--- a/lib/generators/templates/storytime.rb
+++ b/lib/generators/templates/storytime.rb
@@ -47,6 +47,7 @@ Storytime.configure do |config|
   # Enable Discourse comments using your discourse server,
   # Your discourse server must be configured for embedded comments.
   # e.g. config.discourse_name = "http://forum.example.com"
+  # NOTE:  include the '/' suffix at the end of the url
   # config.discourse_name = ""
 
   # Email regex used to validate email format validity for subscriptions.

--- a/lib/generators/templates/storytime.rb
+++ b/lib/generators/templates/storytime.rb
@@ -44,6 +44,11 @@ Storytime.configure do |config|
   # the unique identifier for your website as registered on Disqus.
   # config.disqus_forum_shortname = ""
 
+  # Enable Discourse comments using your discourse server,
+  # Your discourse server must be configured for embedded comments.
+  # e.g. config.discourse_name = "http://forum.example.com"
+  # config.discourse_name = ""
+
   # Email regex used to validate email format validity for subscriptions.
   # config.email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
 

--- a/lib/storytime.rb
+++ b/lib/storytime.rb
@@ -60,6 +60,13 @@ module Storytime
   mattr_accessor :disqus_forum_shortname
   @@disqus_forum_shortname = ""
 
+
+  # Enable Discourse comments using your discourse server,
+  # Your discourse server must be configured for embedded comments.
+  # e.g. config.discourse_name = "http://forum.example.com"
+  mattr_accessor :discourse_name
+  @@discourse_name = ""
+
   # Email regex used to validate email format validity for subscriptions.
   mattr_accessor :email_regexp
   @@email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/

--- a/lib/storytime.rb
+++ b/lib/storytime.rb
@@ -63,6 +63,7 @@ module Storytime
 
   # Enable Discourse comments using your discourse server,
   # Your discourse server must be configured for embedded comments.
+  # NOTE:  include the '/' suffix at the end of the url
   # e.g. config.discourse_name = "http://forum.example.com"
   mattr_accessor :discourse_name
   @@discourse_name = ""

--- a/spec/dummy/config/initializers/storytime.rb
+++ b/spec/dummy/config/initializers/storytime.rb
@@ -34,6 +34,12 @@ Storytime.configure do |config|
   # the unique identifier for your website as registered on Disqus.
   # config.disqus_forum_shortname = ""
 
+  # Enable Discourse comments using your discourse server,
+  # Your discourse server must be configured for embedded comments.
+  # e.g. config.discourse_name = "http://forum.example.com/"
+  # NOTE:  include the '/' suffix at the end of the url
+  # config.discourse_name = ""
+
   # Search adapter to use for searching through Storytime Posts or
   # Post subclasses. Options for the search adapter include:
   # Storytime::PostgresSearchAdapter, Storytime::MysqlSearchAdapter,


### PR DESCRIPTION
This addition will allow storytime to support Discourse forum integration for comments in blog posts the same way it currently supports Disqus. 

I have tested it working with the current master branch. Please see my example blog post http://kickinespresso.com/blog/posts/test-blog-post/ and the discussion page on my own discourse instance http://community.kickinespresso.com/t/storytime/16/2 

Notable changes include:
 - changing the application helper `render_comments`  to support the new commenting system.
 - adding `_discourse.html.erb`
 - adding documentation in the `config/initializers/storytime.rb` and generators

Caveats - You have to choose one commenting system. :-p 