### PR TITLE
Add Storytime.post_sanitizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    storytime (1.2.0)
+    storytime (1.2.1)
       bootstrap-sass (>= 3.1)
       carrierwave (>= 0.9)
       coffee-rails (>= 4.0)

--- a/app/models/storytime/post.rb
+++ b/app/models/storytime/post.rb
@@ -131,7 +131,7 @@ module Storytime
     end
 
     def sanitize_content
-      self.draft_content = sanitize(self.draft_content, tags: Storytime.whitelisted_post_html_tags) unless Storytime.whitelisted_post_html_tags.blank?
+      self.draft_content = Storytime.post_sanitizer.call(self.draft_content) unless Storytime.post_sanitizer.blank?
     end
 
     def set_published_at

--- a/lib/storytime.rb
+++ b/lib/storytime.rb
@@ -55,11 +55,31 @@ module Storytime
   mattr_accessor :whitelisted_post_html_tags
   @@whitelisted_post_html_tags = []
 
+  # Hook for handling post content sanitization.
+  # Accepts either a Lambda or Proc which can be used to
+  # handle how post content is sanitized (i.e. which tags,
+  # HTML attributes to allow/disallow.
+  mattr_accessor :post_sanitizer
+  @@post_sanitizer = Proc.new do |draft_content|
+    if Rails::VERSION::MINOR <= 1
+      white_list_sanitizer = HTML::WhiteListSanitizer.new
+    else
+      white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
+    end
+
+    if Storytime.whitelisted_post_html_tags.blank?
+      white_list_sanitizer.sanitize(draft_content, attributes: %w(class style))
+    else
+      white_list_sanitizer.sanitize(draft_content,
+                                    tags: Storytime.whitelisted_post_html_tags,
+                                    attributes: %w(class style))
+    end
+  end
+
   # Enable Disqus comments using your forum's shortname,
   # the unique identifier for your website as registered on Disqus.
   mattr_accessor :disqus_forum_shortname
   @@disqus_forum_shortname = ""
-
 
   # Enable Discourse comments using your discourse server,
   # Your discourse server must be configured for embedded comments.

--- a/lib/storytime/version.rb
+++ b/lib/storytime/version.rb
@@ -1,3 +1,3 @@
 module Storytime
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
Allows host app to overwrite how post content is sanitized.
-Can remove whitelisted_post_html_tags for Storytime v2 along with
check for whitelisted_post_html_tags in post_sanitizer proc block.