### PR TITLE
Add the ability to specify AWS S3 region

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Storytime.configure do |config|
 end
 ```
 
-Then, you need to set `STORYTIME_AWS_ACCESS_KEY_ID` and `STORYTIME_AWS_SECRET_KEY` as environment variables on your server.
+Then, you need to set `STORYTIME_AWS_ACCESS_KEY_ID` and `STORYTIME_AWS_SECRET_KEY` as environment variables on your server. If your bucket is set to a region that is not the default US Standard (us-east-1) then set `STORYTIME_AWS_REGION`.
 
 ## Email Subscriptions
 

--- a/lib/storytime/engine.rb
+++ b/lib/storytime/engine.rb
@@ -26,7 +26,7 @@ module Storytime
     initializer "storytime.controller_helpers" do
       ActiveSupport.on_load(:action_controller) do
         include Storytime::ControllerHelpers
-        
+
         helper Storytime::SubscriptionsHelper
       end
     end
@@ -48,7 +48,7 @@ module Storytime
         else
           config.storage = :file
         end
-        
+
         config.enable_processing = !Rails.env.test?
       end
     end

--- a/lib/storytime/engine.rb
+++ b/lib/storytime/engine.rb
@@ -38,6 +38,7 @@ module Storytime
           config.storage = :fog
           config.fog_credentials = {
             :provider               => 'AWS',
+            :region                 => ENV['STORYTIME_AWS_REGION'],
             :aws_access_key_id      => ENV['STORYTIME_AWS_ACCESS_KEY_ID'],
             :aws_secret_access_key  => ENV['STORYTIME_AWS_SECRET_KEY']
           }


### PR DESCRIPTION
I found myself unable to use the media uploader as my bucket was based in eu-west-1 & there were no available configuration options to set the bucket for Fog & Carrierwave.

I've implemented it following the same strategy of using environment variables to specify AWS region!