### PR TITLE
Fix #100 - reload media gallery after upload

### DIFF
--- a/app/assets/javascripts/storytime/media.js.coffee
+++ b/app/assets/javascripts/storytime/media.js.coffee
@@ -14,13 +14,8 @@ class Storytime.Dashboard.Media
   initUpload: ()->
     unless @uploadInitialized
       $('#media_file').fileupload({
-        dataType: 'json',
         done: (e, data)->
-          lastRow = $("#media_gallery").children(".row").last()
-          if lastRow.length == 0 || lastRow.children(".col-sm-3").length == 5
-            $("#media_gallery").append("<div class='row'>#{data.result.html}</div>")
-          else
-            lastRow.append(data.result.html)
+          $("#media_gallery_container").html(data.result)
           $("#progress").hide()
           return
         

--- a/app/controllers/storytime/dashboard/media_controller.rb
+++ b/app/controllers/storytime/dashboard/media_controller.rb
@@ -17,14 +17,16 @@ module Storytime
       end
 
       def create
-        @media = Media.new(media_params)
-        @media.user = current_user
+        @upload_media = Media.new(media_params)
+        @upload_media.user = current_user
 
-        authorize @media
-        @media.save
-        respond_with :dashboard, @media do |format|
-          format.json{ render :show }
-        end
+        authorize @upload_media
+        @upload_media.save
+        
+        @media = Media.order("created_at DESC").page(params[:page]).per(10)
+        @large_gallery = false
+
+        render partial: "gallery", content_type: Mime::HTML
       end
       
       def destroy

--- a/app/views/storytime/dashboard/media/_modal.html.erb
+++ b/app/views/storytime/dashboard/media/_modal.html.erb
@@ -16,7 +16,7 @@
 
         <div>
           <%= render "storytime/dashboard/media/form.html.erb" %>
-          <%= render "storytime/dashboard/media/gallery.html.erb" %>
+          <div id="media_gallery_container"><%= render "storytime/dashboard/media/gallery.html.erb" %></div>
         </div>
       </div>
       <div class='modal-footer'>

--- a/app/views/storytime/dashboard/media/index.html.erb
+++ b/app/views/storytime/dashboard/media/index.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="scroll-panel-body">
       <%= render "form" %>
-      <%= render "gallery" %>
+      <div id="media_gallery_container"><%= render "gallery" %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Instead of dealing with new images using JS, just return a partial of the media#gallery view and replace old gallery.

Fix issue with multiple uploads breaking 'done' callback by removing dataType