### PR TITLE
Remove subdomain from Storytime::Site

### DIFF
--- a/db/migrate/20150402161427_remove_subdomain_from_storytime_site.rb
+++ b/db/migrate/20150402161427_remove_subdomain_from_storytime_site.rb
@@ -1,0 +1,5 @@
+class RemoveSubdomainFromStorytimeSite < ActiveRecord::Migration
+  def change
+    remove_column :storytime_sites, :subdomain, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150331162329) do
+ActiveRecord::Schema.define(version: 20150402161427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,7 +137,6 @@ ActiveRecord::Schema.define(version: 20150331162329) do
     t.integer  "root_post_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "subdomain"
     t.string   "subscription_email_from"
     t.string   "layout"
     t.string   "disqus_forum_shortname"


### PR DESCRIPTION
Subdomain isn’t used anywhere in Storytime - popped up during the initial development of multi-site support.