### PR TITLE
Fix issue with nested delete hyperlinks

### DIFF
--- a/app/assets/javascripts/storytime/base.js.coffee
+++ b/app/assets/javascripts/storytime/base.js.coffee
@@ -22,9 +22,10 @@ $ ()->
     alert("There was an error deleting your #{$(@).data('resource-type')}")
   )
 
-  $(".table-row-link").click ->
-    url = $(this).data('url')
-    document.location.href = url
+  $(".table-row-link").on "click", (e) ->
+    unless $(e.target).data("confirm")? || $(e.target).parent("a[data-confirm]").length > 0
+      url = $(@).data('url')
+      document.location.href = url
 
   $(document).on "click", ".storytime-menu-toggle", (e) ->
     e.preventDefault()


### PR DESCRIPTION
Fix issue in admin index view where a nested hyperlink with a confirmation (delete/trashcan button) is clicked and regardless of the confirmation, page redirects to url of parent table row element.