### PR TITLE
Use blog_path with tag parameter instead of tag_path

### DIFF
--- a/app/controllers/storytime/blogs_controller.rb
+++ b/app/controllers/storytime/blogs_controller.rb
@@ -28,7 +28,11 @@ module Storytime
       else
         Post.published.friendly.find(params[:id])
       end
-      redirect_to "/", status: :moved_permanently if @page == @current_storytime_site.homepage
+
+      if @page == @current_storytime_site.homepage
+        opts = params[:tag] ? { tag: params[:tag] } : {}
+        redirect_to storytime.root_path(opts), status: :moved_permanently
+      end
     end
     
     def get_search_type

--- a/app/views/storytime/blogs/_tags.html.erb
+++ b/app/views/storytime/blogs/_tags.html.erb
@@ -1,3 +1,3 @@
 <% post.tags.each do |t| %>
-  <span class='label label-primary'><%= link_to t.name, tag_path(t.name) %></span>
+  <span class='label label-primary'><%= link_to t.name, storytime.blog_path(post.blog, tag: t.name) %></span>
 <% end %>

--- a/app/views/storytime/blogs/show.html.erb
+++ b/app/views/storytime/blogs/show.html.erb
@@ -11,7 +11,7 @@
     <div class="col-md-3">
       <h5>Tags</h5>
       <% tag_cloud Storytime::Post.tag_counts, %w[s m l] do |tag, css_class| %>
-        <div><%= link_to tag.name, tag_path(tag.name), class: css_class %></div>
+        <div><%= link_to tag.name, storytime.blog_path(@page, tag: tag.name), class: css_class %></div>
       <% end %>
     </div>
   </div>

--- a/app/views/storytime/posts/_tags.html.erb
+++ b/app/views/storytime/posts/_tags.html.erb
@@ -1,3 +1,3 @@
 <% post.tags.each do |t| %>
-  <span class='label label-primary'><%= link_to t.name, storytime.tag_path(t.name) %></span>
+  <span class='label label-primary'><%= link_to t.name, storytime.blog_path(post.blog, tag: t.name) %></span>
 <% end %>


### PR DESCRIPTION
Addresses #153 where link_to helpers are still pointing to the now non-existent tag route.