### PR TITLE
Bootstrap compatibility fix

### DIFF
--- a/app/assets/javascripts/storytime/application.js
+++ b/app/assets/javascripts/storytime/application.js
@@ -13,7 +13,7 @@
 //= require_self
 //= require jquery
 //= require jquery_ujs
-//= require bootstrap
+//= require bootstrap-sprockets
 //= require leather
 //= require cocoon
 //= require jquery-ui/core

--- a/app/assets/javascripts/storytime/base.js.coffee
+++ b/app/assets/javascripts/storytime/base.js.coffee
@@ -9,7 +9,8 @@ initJS = (controller, action) ->
 $ ()->
   initJS($("body").data("controller"), $("body").data("action"))
 
-  $(".flash").delay(4000).fadeOut() unless window.Storytime.test_env
+  debugger
+  $(".flash").delay(4000).fadeOut() unless window.Storytime.test_env || window.Storytime.persistent_flash_message
 
   $(".chosen").chosen()
 

--- a/app/assets/javascripts/storytime/base.js.coffee
+++ b/app/assets/javascripts/storytime/base.js.coffee
@@ -9,7 +9,6 @@ initJS = (controller, action) ->
 $ ()->
   initJS($("body").data("controller"), $("body").data("action"))
 
-  debugger
   $(".flash").delay(4000).fadeOut() unless window.Storytime.test_env || window.Storytime.persistent_flash_message
 
   $(".chosen").chosen()

--- a/storytime.gemspec
+++ b/storytime.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "font-awesome-sass", ">= 4.0.3"
   s.add_dependency "jquery-ui-rails", "~> 5.0"
   s.add_dependency "thor", "~> 0.19.1"
-  s.add_dependency "leather", "~> 3.3.3"
+  s.add_dependency "leather", "~> 3.3.4"
   s.add_dependency "codemirror-rails", "~> 4.8"
   s.add_dependency "storytime-admin", "~> 0.2.0"
   s.add_dependency "devise", ">= 3.2"


### PR DESCRIPTION
Changed Sprockets Bootstrap require to `bootstrap-sprockets` so if host app also uses Bootstrap, it won't be included twice.