### PR TITLE
Bootstrap compatibility fix

### DIFF
--- a/app/assets/javascripts/storytime/application.js
+++ b/app/assets/javascripts/storytime/application.js
@@ -13,7 +13,7 @@
 //= require_self
 //= require jquery
 //= require jquery_ujs
-//= require bootstrap
+//= require bootstrap-sprockets
 //= require leather
 //= require cocoon
 //= require jquery-ui/core


### PR DESCRIPTION
Changed Sprockets Bootstrap require to bootstrap-sprockets so if host app also uses Bootstrap, it won't be included twice.